### PR TITLE
Refactor: Firestore 사용자 정보 경로 변경 및 디버깅 로그 추가

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -6,8 +6,8 @@ import 'show/show_list_page.dart';
 import 'reservation/reservation_list_page.dart';
 import '../admin/admin_venue_setup_page.dart';
 import '../admin/admin_show_create_page.dart';
-import '../admin/main_hall_seat_initializer_page.dart'; // 🔥 파일 이름 변경 반영
-import 'seat_selection/main_hall_canvas_page.dart'; // ✅ 파일 이름 변경 반영
+import '../admin/main_hall_seat_initializer_page.dart';
+import 'seat_selection/main_hall_canvas_page.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -123,18 +123,17 @@ class HomePage extends StatelessWidget {
               ),
               const SizedBox(height: 16),
 
-              // ✅ 추가된 고척돔 좌석 초기화 버튼
               ElevatedButton.icon(
                 onPressed: () {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => const MainHallSeatInitializerPage(), // 클래스 이름 변경
+                      builder: (context) => const MainHallSeatInitializerPage(),
                     ),
                   );
                 },
                 icon: const Icon(Icons.event_seat),
-                label: const Text('메인홀 좌석 초기화'), // 버튼 텍스트도 변경
+                label: const Text('메인홀 좌석 초기화'),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.deepPurple,
                   foregroundColor: Colors.white,
@@ -146,24 +145,24 @@ class HomePage extends StatelessWidget {
               ),
               const SizedBox(height: 16),
 
-              // ✅ 추가된 캔버스 좌석도 보기 버튼 (테스트용 더미 데이터 전달)
+              // ✅ 캔버스 좌석도 보기 버튼 (테스트용 더미 데이터 전달 - 실제 예매된 값으로 변경)
               ElevatedButton.icon(
                 onPressed: () {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => MainHallCanvasPage( // 클래스 이름 변경
-                        showId: 'test_show_id', // 더미 ID
-                        showTitle: '테스트 공연', // 더미 제목
-                        selectedDateTime: '2025-07-19T18:00:00', // 더미 날짜
-                        venueId: 'main_hall', // venueId도 'main_hall'로 변경
-                        maxTicketsPerUser: 4, // 더미 최대 매수
+                      builder: (context) => MainHallCanvasPage(
+                        showId: 'HOzESJZICTCIeLvITbGO', // ✅ 실제 예매된 showId
+                        showTitle: '테스트', // ✅ 실제 예매된 showTitle
+                        selectedDateTime: '2025-06-11 20:00', // ✅ 실제 예매된 dateTime
+                        venueId: 'main_hall', // ✅ Firebase에 초기화된 venueId
+                        maxTicketsPerUser: 4,
                       ),
                     ),
                   );
                 },
                 icon: const Icon(Icons.map),
-                label: const Text('메인홀 좌석 배치도 보기'), // 버튼 텍스트도 변경
+                label: const Text('메인홀 좌석 배치도 보기'),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.deepPurple,
                   foregroundColor: Colors.white,

--- a/lib/screens/reservation/reservation_detail_page.dart
+++ b/lib/screens/reservation/reservation_detail_page.dart
@@ -21,13 +21,20 @@ class _ReservationDetailPageState extends State<ReservationDetailPage> {
     _loadUserNickname();
   }
 
-  // ✅ 사용자 닉네임을 Firestore에서 불러오는 함수 (경로 일치)
+  // ✅ 사용자 닉네임을 Firestore에서 불러오는 함수 (경로 변경)
   Future<void> _loadUserNickname() async {
     final userId = widget.reservation['userId'];
     if (userId != null && userId.isNotEmpty) {
+      final String appId = const String.fromEnvironment('APP_ID', defaultValue: 'default-app-id');
+
       try {
-        // 사용자 정보 조회 경로: users/{userId} (AuthService에서 저장하는 경로와 일치)
-        final userDoc = await FirebaseFirestore.instance.collection('users').doc(userId).get();
+        // 사용자 정보 조회 경로 변경: artifacts/{appId}/users/{userId}
+        final userDoc = await FirebaseFirestore.instance
+            .collection('artifacts')
+            .doc(appId)
+            .collection('users')
+            .doc(userId)
+            .get();
 
         if (userDoc.exists) {
           setState(() {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -13,9 +13,14 @@ class AuthService {
 
     User? user = userCredential.user;
     if (user != null) {
-      // ✅ Firestore에 사용자 정보 저장 경로: users/{user.uid} (최상위 컬렉션)
+      // Canvas 환경의 appId를 가져옵니다.
+      final String appId = const String.fromEnvironment('APP_ID', defaultValue: 'default-app-id');
+
+      // ✅ Firestore에 사용자 정보 저장 경로 변경: artifacts/{appId}/users/{user.uid}
       await _firestore
-          .collection('users') // 'users' 컬렉션 (루트 레벨)
+          .collection('artifacts')
+          .doc(appId)
+          .collection('users') // users 서브컬렉션
           .doc(user.uid)
           .set({
         'email': user.email,


### PR DESCRIPTION
- Firestore에서 사용자 정보를 저장하고 조회하는 경로를 `users/{userId}`에서 `artifacts/{appId}/users/{userId}`로 변경했습니다. 이는 Canvas 환경의 appId를 사용합니다.
- `main_hall_canvas_page.dart`의 `_loadSeatsForSection` 메서드에 좌석 로딩 과정 및 예약 정보 조회 관련 디버깅 로그를 추가했습니다.
- `main_hall_canvas_page.dart`에서 `showShowTimePicker` 호출 시 불필요한 `await` 키워드를 제거했습니다.
- `home_page.dart`의 캔버스 좌석도 보기 버튼에 실제 예매된 데이터로 변경했습니다. (showId, showTitle, selectedDateTime, venueId)
- `home_page.dart`의 주석에서 파일 이름 변경 관련 내용을 제거했습니다.